### PR TITLE
Fixed issue with message body class name change by Slack

### DIFF
--- a/source/slack-hebrew.js
+++ b/source/slack-hebrew.js
@@ -20,7 +20,7 @@ function applyTo(element) {
 }
 
 function setDirections() {
-    var contents = document.getElementsByClassName('message_body');
+    var contents = document.getElementsByClassName('c-message__body');
     for (var i in contents) {
         var element = contents[i];
         if (!elementShouldBeRTL(element))


### PR DESCRIPTION
Slack have changed the class name on messages from `message_body` to `c-message__body` and as such the extension no longer does what it is supposed to since it no longer looks in the right place for messages with RTL.